### PR TITLE
Feature - Send map bounds to server on change

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
-import React, { Component } from "react";
-import "./App.css";
-import Map from "./Components/Map";
+import React, {Component} from 'react';
+import './App.css';
+import Map from './components/Map';
 
 class App extends Component {
   render() {

--- a/src/Components/Map/index.js
+++ b/src/Components/Map/index.js
@@ -1,25 +1,25 @@
 // Reference: https://github.com/tomchentw/react-google-maps/blob/master/src/components/GoogleMap.md
-import React from "react";
-import { compose, withHandlers, withProps } from "recompose";
+import React from 'react';
+import {compose, withHandlers, withProps} from 'recompose';
 import {
   withScriptjs,
   withGoogleMap,
   GoogleMap,
-  Marker
-} from "react-google-maps";
-import axios from "axios";
+  Marker,
+} from 'react-google-maps';
+import axios from 'axios';
 
 const Map = compose(
   withProps({
     googleMapURL:
-      "https://maps.googleapis.com/maps/api/js?key=AIzaSyB-wDNI3bGVreubWNQkWvjHlL15a7Bcx48&v=3.exp&libraries=geometry,drawing,places",
-    loadingElement: <div style={{ height: `100%` }} />,
-    containerElement: <div style={{ height: `400px` }} />,
-    mapElement: <div style={{ height: `100%` }} />
+      'https://maps.googleapis.com/maps/api/js?key=AIzaSyB-wDNI3bGVreubWNQkWvjHlL15a7Bcx48&v=3.exp&libraries=geometry,drawing,places',
+    loadingElement: <div style={{height: `100%`}} />,
+    containerElement: <div style={{height: `400px`}} />,
+    mapElement: <div style={{height: `100%`}} />,
   }),
   withHandlers(props => {
     const refs = {
-      map: undefined
+      map: undefined,
     };
 
     return {
@@ -33,7 +33,7 @@ const Map = compose(
       // },
       onBoundsChanged: () => () => {
         props.handleBounds(refs.map);
-      }
+      },
     };
   }),
   withScriptjs,
@@ -41,13 +41,13 @@ const Map = compose(
 )(props => (
   <GoogleMap
     defaultZoom={5}
-    defaultCenter={{ lat: 41.850033, lng: -87.6500523 }}
+    defaultCenter={{lat: 41.850033, lng: -87.6500523}}
     ref={props.onMapMounted}
     onBoundsChanged={props.onBoundsChanged}
   >
     {props.isMarkerShown && (
       <Marker
-        position={{ lat: 41.850033, lng: -87.6500523 }}
+        position={{lat: 41.850033, lng: -87.6500523}}
         onClick={props.onMarkerClick}
       />
     )}
@@ -55,21 +55,32 @@ const Map = compose(
 ));
 
 class MapWrapper extends React.PureComponent {
+  state = {
+    bounds: {
+      northEast: null,
+      southWest: null,
+    },
+  };
+
   componentDidMount() {
-    //this.delayedShowMarker();
-    this.fetchMarkers();
+    this._fetchMarkers();
   }
 
   // PRIVATE
 
   _handleBounds = map => {
-    console.log("handling bounds change: ", map.getBounds());
+    let northEast = map.getBounds().getNorthEast();
+    let southWest = map.getBounds().getSouthWest();
+
+    northEast = {lat: northEast.lat(), lng: northEast.lng()};
+    southWest = {lat: southWest.lat(), lng: southWest.lng()};
+    this.setState({bounds: {northEast, southWest}}, () => this._fetchMarkers());
   };
 
-  fetchMarkers = () => {
-    const data = null;
-    const request = axios
-      .post("http://localhost:6001/get-markers", { test: data })
+  _fetchMarkers = () => {
+    const {bounds} = this.state;
+    axios
+      .post('http://localhost:6001/get-markers', {bounds})
       .then(res => console.log(res.data));
   };
   render() {


### PR DESCRIPTION
## Reason 

We need to send the map bounds to the server so that the server can execute the query for markers contained within the bounding box

## Changes 
- Updated `<Map />` - added `bounds` to state, updates via `_handleBounds`
- Updated `<Map />` `_fetchMarkders` - added `bounds` to axios call
- Updated `Components` directory - renamed to `components`

## Notes 
Server now gets bounds:
![image](https://user-images.githubusercontent.com/4824919/39758376-ea92a97e-528c-11e8-94f8-683b7f9471d0.png)

closes #5 

